### PR TITLE
improve tooling scripts

### DIFF
--- a/import-database-directory.sh
+++ b/import-database-directory.sh
@@ -8,7 +8,7 @@ echo "= = ="
 
 if [ -z ${MESSAGE_DB_HOME+x} ]; then
   echo "MESSAGE_DB_HOME is not set"
-  exit
+  exit 1
 fi
 
 default_database_source="$MESSAGE_DB_HOME/message-db/database"

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 ./clean.sh
 ./import-database-scripts.sh
 npm pack

--- a/package.sh
+++ b/package.sh
@@ -3,5 +3,5 @@
 set -e
 
 ./clean.sh
-./import-database-scripts.sh
+./import-database-directory.sh
 npm pack


### PR DESCRIPTION
The lack of proper error propagation and missing `set -e` meant the `package.sh` script was silent when failing to import the database files ahead of a publish.